### PR TITLE
Fix loader keeps spinning if hideLoader is called immediately after showLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Head
+
+- Fix a bug where the loader is not being hidden when calling hideLoader inmediately after showLoader with a zero delay [#1](https://github.com/SDOSLabs/SDOSLoader/issues/1)
+
 ## [3.1.0 Support Swift Package Manager](https://github.com/SDOSLabs/SDOSLoader/tree/3.1.0)
 
 -  Add support for Swift Package Manager

--- a/src/Classes/Manager/LoaderManager.swift
+++ b/src/Classes/Manager/LoaderManager.swift
@@ -90,7 +90,11 @@ public class LoaderManager: NSObject {
     public class func showLoader(_ loaderObject: LoaderObject?, delay: TimeInterval = 0) {
         if let loaderObject = loaderObject {
             hideLoader(loaderObject)
-            self.perform(#selector(_showLoader(_:)), with: loaderObject, afterDelay: delay)
+            if delay > 0 {
+                self.perform(#selector(_showLoader(_:)), with: loaderObject, afterDelay: delay)
+            } else {
+                self._showLoader(loaderObject)
+            }
         }
     }
     


### PR DESCRIPTION
Fix for issue #1 